### PR TITLE
Add Deepen Membership landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deepen Membership</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      line-height: 1.6;
+      color: #333;
+    }
+    header, section, footer {
+      padding: 40px 20px;
+      max-width: 800px;
+      margin: 0 auto;
+    }
+    header {
+      background: #f0f4f5;
+      text-align: center;
+    }
+    h1 {
+      margin-top: 0;
+      font-size: 2.4em;
+    }
+    .cta {
+      display: inline-block;
+      margin: 20px 0;
+      padding: 10px 20px;
+      background: #357edd;
+      color: #fff;
+      text-decoration: none;
+      border-radius: 4px;
+    }
+    .section-title {
+      font-size: 1.8em;
+      margin-bottom: 10px;
+    }
+    ul {
+      list-style: none;
+      padding: 0;
+    }
+    li::before {
+      content: "\2713 \0020";
+      color: #357edd;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 20px 0;
+    }
+    th, td {
+      border: 1px solid #ccc;
+      padding: 8px;
+      text-align: left;
+    }
+    footer {
+      background: #f0f4f5;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>DEEPEN MEMBERSHIP</h1>
+    <p>Go deeper. Live with clarity.<br>More than connection.<br>This is real practice, held in lineage — with live guidance and transformative depth.</p>
+    <a href="#" class="cta">Join Now – $48/month or $240 for 6 months</a>
+  </header>
+
+  <section>
+    <h2 class="section-title">Why This Membership Exists</h2>
+    <p>You’re not looking for more information.<br>You’re looking for integration — a way to embody what you know matters.</p>
+    <blockquote>“There’s depth here I haven’t found anywhere else. This is not content — it’s transformation.”<br><em>– Deepen Member</em></blockquote>
+  </section>
+
+  <section>
+    <h2 class="section-title">What You Receive</h2>
+    <p>Everything in the Connect Membership, plus:</p>
+    <ul>
+      <li><strong>The Craft of Zen</strong> — A 6-month contemplative training guided by Nicole Baden Roshi. Discover five essential qualities to orient your life from within.</li>
+      <li><strong>Live Monthly Teachings</strong> — Direct, in-depth guidance to refine your practice — and meet life awake.</li>
+      <li><strong>Practice Paths: Wisdom & Compassion</strong> — Structured exercises to anchor insight in your daily experience.</li>
+      <li><strong>Recorded Weekly Talks from Zentatsu Baker Roshi</strong> — Unpublished teachings from a living lineage — now accessible to you.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2 class="section-title">This Is For You If...</h2>
+    <ul>
+      <li>You want more than inspiration — you want integration.</li>
+      <li>You’re ready to walk a path, not wander through content.</li>
+      <li>You sense there’s more — and you’re ready to meet it.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2 class="section-title">Before & After</h2>
+    <table>
+      <tr>
+        <th>Without It</th>
+        <th>With It</th>
+      </tr>
+      <tr>
+        <td>Consuming teachings</td>
+        <td>Embodying transformation</td>
+      </tr>
+      <tr>
+        <td>Confusion, overwhelm</td>
+        <td>Clear, structured path</td>
+      </tr>
+      <tr>
+        <td>Solo practice, no feedback</td>
+        <td>Guidance from a living lineage</td>
+      </tr>
+    </table>
+  </section>
+
+  <section>
+    <h2 class="section-title">What Members Say</h2>
+    <blockquote>“It feels like being held — not just by teachings, but by a living tradition.”<br><em>– Josephine L., Switzerland</em></blockquote>
+    <blockquote>“Nicole doesn’t just teach. She transmits.”<br><em>– Aaron M., Canada</em></blockquote>
+  </section>
+
+  <section>
+    <h2 class="section-title">Honest Pricing</h2>
+    <p>Monthly: $48<br>6 Months (save 17%): $240</p>
+    <ul>
+      <li>Full access to all trainings</li>
+      <li>Cancel anytime – stay until your cycle ends</li>
+      <li>Seamless upgrade from Connect Membership</li>
+    </ul>
+    <a href="#" class="cta">Join the Deepen Membership Now</a>
+  </section>
+
+  <section>
+    <h2 class="section-title">FAQ</h2>
+    <p><strong>Q: Can I start anytime?</strong><br>Yes — your 6-month journey begins the day you join.</p>
+    <p><strong>Q: Is this for advanced practitioners?</strong><br>Not necessarily. It’s for those who are serious — not necessarily experienced.</p>
+    <p><strong>Q: What if I miss a live session?</strong><br>All sessions are recorded. You’ll never miss a step.</p>
+  </section>
+
+  <section>
+    <h2 class="section-title">Ready to walk a path that holds you?</h2>
+    <a href="#" class="cta">Join Now – $48/month or $240 for 6 months</a>
+  </section>
+
+  <footer>
+    <p>No fluff. No overwhelm.<br>Just deep practice, real guidance, and a path that grows with you.</p>
+  </footer>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- add `index.html` with modern membership landing page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853f7d143848327b0f3c5e9fc56d0f3